### PR TITLE
Improve OCR initialization and enhance UI element lookup reliability

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,6 +14,7 @@ env:
   DOTNET_VERSION: '10.0.x'
   PROJECT_PATH: 'ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj'
   OUTPUT_NAME: 'ToonTown-Rewritten-Bot'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -115,7 +115,7 @@ jobs:
         echo "SHORT_SHA=$sha" >> $env:GITHUB_OUTPUT
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.OUTPUT_NAME }}-dev-${{ steps.short_sha.outputs.SHORT_SHA }}
         path: ./release/

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -114,7 +114,7 @@ jobs:
         echo "SHORT_SHA=$sha" >> $env:GITHUB_OUTPUT
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ env.OUTPUT_NAME }}-dev-${{ steps.short_sha.outputs.SHORT_SHA }}
         path: ./release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
   DOTNET_VERSION: '10.0.x'
   PROJECT_PATH: 'ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj'
   OUTPUT_NAME: 'ToonTown-Rewritten-Bot'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ env.OUTPUT_NAME }}-${{ steps.get_version.outputs.VERSION }}
         path: ./release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.OUTPUT_NAME }}-${{ steps.get_version.outputs.VERSION }}
         path: ./release/

--- a/ToonTown Rewritten Bot/Properties/AssemblyInfo.cs
+++ b/ToonTown Rewritten Bot/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.3.1.0")]
+[assembly: AssemblyFileVersion("2.3.1.0")]

--- a/ToonTown Rewritten Bot/Services/DoodleTraining.cs
+++ b/ToonTown Rewritten Bot/Services/DoodleTraining.cs
@@ -89,8 +89,23 @@ namespace ToonTown_Rewritten_Bot.Services
             _justFeed = justFeed;
             _justScratch = justScratch;
 
-            // Initialize OCR for SpeedChat menu reading
-            _ocr = new TextRecognition();
+            // Only initialize OCR if tricks are selected (feed/scratch don't need it)
+            if (_selectedTrick != "None")
+            {
+                try
+                {
+                    _ocr = new TextRecognition();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Doodle", $"OCR initialization failed: {ex.Message}");
+                    throw new InvalidOperationException(
+                        "OCR initialization failed. Trick training requires OCR.\n\n" +
+                        "Try clicking 'Download OCR Data' on the Dev tab, then restart the app.\n\n" +
+                        "Feed and scratch training can still be used without OCR by selecting trick 'None'.",
+                        ex);
+                }
+            }
 
             // Doodle training always uses foreground mode (background mode is for fishing only)
             bool savedBackgroundMode = UseBackgroundInput;

--- a/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj
+++ b/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj
@@ -14,7 +14,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.3.0.0</ApplicationVersion>
+    <ApplicationVersion>2.3.1.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/ToonTown Rewritten Bot/Utilities/GlobalSettings.cs
+++ b/ToonTown Rewritten Bot/Utilities/GlobalSettings.cs
@@ -4,7 +4,7 @@
     {
         public static class ApplicationInfo
         {
-            public static string Version { get; } = "2.3.0";
+            public static string Version { get; } = "2.3.1";
             public static string Author { get; } = "primetime43";
         }
     }

--- a/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
+++ b/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
@@ -44,16 +44,32 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 }
             }
 
+            // Log diagnostic info for debugging OCR init issues
+            string x64Dir = Path.Combine(AppPaths.ExeDirectory, "x64");
+            Logger.Info("OCR", $"Initializing Tesseract OCR...");
+            Logger.Info("OCR", $"ExeDirectory: {AppPaths.ExeDirectory}");
+            Logger.Info("OCR", $"TessData path: {dataPath}");
+            Logger.Info("OCR", $"tessdata exists: {Directory.Exists(dataPath)}");
+            Logger.Info("OCR", $"eng.traineddata exists: {File.Exists(Path.Combine(dataPath, "eng.traineddata"))}");
+            Logger.Info("OCR", $"x64 dir exists: {Directory.Exists(x64Dir)}");
+            Logger.Info("OCR", $"tesseract50.dll exists: {File.Exists(Path.Combine(x64Dir, "tesseract50.dll"))}");
+            Logger.Info("OCR", $"leptonica-1.82.0.dll exists: {File.Exists(Path.Combine(x64Dir, "leptonica-1.82.0.dll"))}");
+#pragma warning disable IL3000 // Intentionally logging Assembly.Location for diagnostics
+            Logger.Info("OCR", $"Assembly.Location: '{typeof(TesseractEngine).Assembly.Location}'");
+#pragma warning restore IL3000
+
             // Tell Tesseract where to find its native DLLs.
             // In single-file published executables, Assembly.Location returns empty string,
             // causing Tesseract's internal path resolver to pass null to Path.Combine.
             // Setting CustomSearchPath bypasses that broken resolution entirely.
             // Note: Tesseract auto-appends the platform folder (x64) to this path.
             TesseractEnviornment.CustomSearchPath = AppPaths.ExeDirectory;
+            Logger.Info("OCR", $"Set CustomSearchPath to: {AppPaths.ExeDirectory}");
 
             try
             {
                 _engine = new TesseractEngine(dataPath, language, EngineMode.Default);
+                Logger.Info("OCR", "Tesseract engine initialized successfully");
             }
             catch (Exception ex)
             {
@@ -63,6 +79,9 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 {
                     innerEx = innerEx.InnerException;
                 }
+
+                Logger.Error("OCR", $"Tesseract init failed: {innerEx.GetType().Name}: {innerEx.Message}");
+                Logger.Error("OCR", $"Stack trace: {innerEx.StackTrace}");
 
                 throw new InvalidOperationException(
                     $"Failed to initialize Tesseract OCR engine: {innerEx.Message}\n\n" +

--- a/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
+++ b/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Tesseract;
@@ -561,23 +562,26 @@ namespace ToonTown_Rewritten_Bot.Utilities
         #region Helper Methods
 
         /// <summary>
-        /// Checks that native Tesseract DLLs exist before attempting to load them.
-        /// Throws a clear error message if missing.
+        /// Verifies native Tesseract DLLs exist and pre-loads them into the process.
+        /// In single-file published executables, Assembly.Location returns empty string,
+        /// causing Tesseract's internal path resolver to pass null to Path.Combine and crash
+        /// with "Value cannot be null (Parameter 'path1')". By loading the DLLs ourselves
+        /// before TesseractEngine is created, the P/Invoke calls find them already loaded.
         /// </summary>
         private static void VerifyNativeDlls()
         {
             string x64Dir = Path.Combine(AppPaths.ExeDirectory, "x64");
-            string tesseractDll = Path.Combine(x64Dir, "tesseract50.dll");
             string leptonicaDll = Path.Combine(x64Dir, "leptonica-1.82.0.dll");
+            string tesseractDll = Path.Combine(x64Dir, "tesseract50.dll");
 
             var missing = new System.Collections.Generic.List<string>();
-            if (!File.Exists(tesseractDll))
-            {
-                missing.Add("x64/tesseract50.dll");
-            }
             if (!File.Exists(leptonicaDll))
             {
                 missing.Add("x64/leptonica-1.82.0.dll");
+            }
+            if (!File.Exists(tesseractDll))
+            {
+                missing.Add("x64/tesseract50.dll");
             }
 
             if (missing.Count > 0)
@@ -587,6 +591,23 @@ namespace ToonTown_Rewritten_Bot.Utilities
                     $"Expected location: {x64Dir}\n\n" +
                     "These files are required for OCR features (doodle tricks, auto golf).\n" +
                     "Please re-download the bot or copy the x64 folder next to the executable.");
+            }
+
+            // Pre-load native DLLs so Tesseract's P/Invoke finds them already in the process.
+            // Leptonica must be loaded first since tesseract50.dll depends on it.
+            if (!NativeLibrary.TryLoad(leptonicaDll, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Failed to load native library: {leptonicaDll}\n\n" +
+                    "This may indicate a missing Visual C++ Redistributable.\n" +
+                    "Download it from: https://aka.ms/vs/17/release/vc_redist.x64.exe");
+            }
+            if (!NativeLibrary.TryLoad(tesseractDll, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Failed to load native library: {tesseractDll}\n\n" +
+                    "This may indicate a missing Visual C++ Redistributable.\n" +
+                    "Download it from: https://aka.ms/vs/17/release/vc_redist.x64.exe");
             }
         }
 

--- a/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
+++ b/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
@@ -44,7 +44,28 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 }
             }
 
-            _engine = new TesseractEngine(dataPath, language, EngineMode.Default);
+            // Check for native Tesseract DLLs before attempting to load
+            VerifyNativeDlls();
+
+            try
+            {
+                _engine = new TesseractEngine(dataPath, language, EngineMode.Default);
+            }
+            catch (Exception ex)
+            {
+                // Unwrap TargetInvocationException to show the real cause
+                var innerEx = ex;
+                while (innerEx is System.Reflection.TargetInvocationException && innerEx.InnerException != null)
+                {
+                    innerEx = innerEx.InnerException;
+                }
+
+                throw new InvalidOperationException(
+                    $"Failed to initialize Tesseract OCR engine: {innerEx.Message}\n\n" +
+                    "Make sure the x64 folder containing tesseract50.dll and leptonica-1.82.0.dll " +
+                    "is in the same directory as the executable.",
+                    innerEx);
+            }
         }
 
         /// <summary>
@@ -538,6 +559,36 @@ namespace ToonTown_Rewritten_Bot.Utilities
         }
 
         #region Helper Methods
+
+        /// <summary>
+        /// Checks that native Tesseract DLLs exist before attempting to load them.
+        /// Throws a clear error message if missing.
+        /// </summary>
+        private static void VerifyNativeDlls()
+        {
+            string x64Dir = Path.Combine(AppPaths.ExeDirectory, "x64");
+            string tesseractDll = Path.Combine(x64Dir, "tesseract50.dll");
+            string leptonicaDll = Path.Combine(x64Dir, "leptonica-1.82.0.dll");
+
+            var missing = new System.Collections.Generic.List<string>();
+            if (!File.Exists(tesseractDll))
+            {
+                missing.Add("x64/tesseract50.dll");
+            }
+            if (!File.Exists(leptonicaDll))
+            {
+                missing.Add("x64/leptonica-1.82.0.dll");
+            }
+
+            if (missing.Count > 0)
+            {
+                throw new FileNotFoundException(
+                    $"Missing native OCR libraries: {string.Join(", ", missing)}\n\n" +
+                    $"Expected location: {x64Dir}\n\n" +
+                    "These files are required for OCR features (doodle tricks, auto golf).\n" +
+                    "Please re-download the bot or copy the x64 folder next to the executable.");
+            }
+        }
 
         private Pix BitmapToPix(Bitmap bitmap)
         {

--- a/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
+++ b/ToonTown Rewritten Bot/Utilities/TextRecognition.cs
@@ -2,7 +2,6 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Tesseract;
@@ -45,8 +44,12 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 }
             }
 
-            // Check for native Tesseract DLLs before attempting to load
-            VerifyNativeDlls();
+            // Tell Tesseract where to find its native DLLs.
+            // In single-file published executables, Assembly.Location returns empty string,
+            // causing Tesseract's internal path resolver to pass null to Path.Combine.
+            // Setting CustomSearchPath bypasses that broken resolution entirely.
+            // Note: Tesseract auto-appends the platform folder (x64) to this path.
+            TesseractEnviornment.CustomSearchPath = AppPaths.ExeDirectory;
 
             try
             {
@@ -562,11 +565,8 @@ namespace ToonTown_Rewritten_Bot.Utilities
         #region Helper Methods
 
         /// <summary>
-        /// Verifies native Tesseract DLLs exist and pre-loads them into the process.
-        /// In single-file published executables, Assembly.Location returns empty string,
-        /// causing Tesseract's internal path resolver to pass null to Path.Combine and crash
-        /// with "Value cannot be null (Parameter 'path1')". By loading the DLLs ourselves
-        /// before TesseractEngine is created, the P/Invoke calls find them already loaded.
+        /// Verifies native Tesseract DLLs exist before attempting to load them.
+        /// Throws a clear error message if missing.
         /// </summary>
         private static void VerifyNativeDlls()
         {
@@ -591,23 +591,6 @@ namespace ToonTown_Rewritten_Bot.Utilities
                     $"Expected location: {x64Dir}\n\n" +
                     "These files are required for OCR features (doodle tricks, auto golf).\n" +
                     "Please re-download the bot or copy the x64 folder next to the executable.");
-            }
-
-            // Pre-load native DLLs so Tesseract's P/Invoke finds them already in the process.
-            // Leptonica must be loaded first since tesseract50.dll depends on it.
-            if (!NativeLibrary.TryLoad(leptonicaDll, out _))
-            {
-                throw new InvalidOperationException(
-                    $"Failed to load native library: {leptonicaDll}\n\n" +
-                    "This may indicate a missing Visual C++ Redistributable.\n" +
-                    "Download it from: https://aka.ms/vs/17/release/vc_redist.x64.exe");
-            }
-            if (!NativeLibrary.TryLoad(tesseractDll, out _))
-            {
-                throw new InvalidOperationException(
-                    $"Failed to load native library: {tesseractDll}\n\n" +
-                    "This may indicate a missing Visual C++ Redistributable.\n" +
-                    "Download it from: https://aka.ms/vs/17/release/vc_redist.x64.exe");
             }
         }
 

--- a/ToonTown Rewritten Bot/Utilities/UIElementManager.cs
+++ b/ToonTown Rewritten Bot/Utilities/UIElementManager.cs
@@ -90,22 +90,19 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 }
             }
 
+            // If we have cached coordinates, trust them without re-verifying.
+            // UI elements like buttons don't move during a session, and re-verifying
+            // via template matching on every call is unreliable (PrintWindow can return
+            // partial frames from 3D-rendered games).
+            if (!forceSearch && element.HasCachedCoordinates)
+            {
+                Logger.Debug("TemplateMatch", $"'{elementName}' using cached location");
+                return element.CachedCenter;
+            }
+
             // Now we have a template, try image recognition
             if (HasTemplate(elementName))
             {
-                // If we have cached coordinates and not forcing search, verify first
-                if (!forceSearch && element.HasCachedCoordinates)
-                {
-                    // Quick verify at cached location
-                    bool stillThere = await VerifyElementAtLocationAsync(elementName, element.CachedCenter.Value);
-                    if (stillThere)
-                    {
-                        Logger.Debug("TemplateMatch", $"'{elementName}' found at cached location");
-                        return element.CachedCenter;
-                    }
-                    Logger.Debug("TemplateMatch", $"'{elementName}' not at cached location, searching...");
-                }
-
                 // Search for the element
                 var result = await FindElementAsync(elementName);
                 if (result.HasValue)
@@ -118,7 +115,15 @@ namespace ToonTown_Rewritten_Bot.Utilities
                 }
             }
 
-            // Image rec failed - offer to recapture or add variant
+            // Image rec failed — fall back to manual/cached coordinates silently
+            // before interrupting the user with a recapture dialog
+            if (element.ManualCoordinates.HasValue)
+            {
+                Logger.Info("TemplateMatch", $"Image rec failed, using manual coordinates for '{elementName}'");
+                return element.ManualCoordinates;
+            }
+
+            // No fallback available — offer to recapture or add variant
             if (HasTemplate(elementName))
             {
                 Logger.Info("TemplateMatch", $"Template exists for '{elementName}' but could not find it on screen");
@@ -135,13 +140,6 @@ namespace ToonTown_Rewritten_Bot.Utilities
                         return retryResult;
                     }
                 }
-            }
-
-            // Check if we have manual coordinates as fallback
-            if (element.ManualCoordinates.HasValue)
-            {
-                Logger.Info("TemplateMatch", $"Using manual coordinates for '{elementName}'");
-                return element.ManualCoordinates;
             }
 
             Logger.Warning("TemplateMatch", $"Could not find '{elementName}'");


### PR DESCRIPTION
## v2.3.1 - Bug Fixes

  ### Bug Fixes

  - **Fix intermittent "can't find Red Fishing Button" dialog (#80):** Cached UI element coordinates are now trusted
  without re-verifying via template matching on every call. The recapture dialog now only appears when no cached or
  manual fallback coordinates are available, restoring the silent fallback behavior from before v2.3.0.

  - **Fix OCR initialization crash for single-file published executables (#78):** Doodle training and auto golf would
  crash with "Exception has been thrown by the target of an invocation" because Tesseract's internal DLL resolver uses
  `Assembly.Location`, which returns empty in single-file apps. Fixed by setting `TesseractEnviornment.CustomSearchPath`
   to the exe directory before engine initialization. Added diagnostic logging for OCR init success/failure.

  - **Fix doodle training crash when OCR fails (#78):** Feed and scratch training no longer require OCR — it's only
  initialized when a trick is selected. Users whose OCR fails can still use feed/scratch by setting trick to "None".

  ### Performance

  - **Speed up doodle training (#77):** UI element coordinates (SpeedChat button, Feed button, Scratch button) are
  cached after first detection and reused on subsequent calls, eliminating redundant template matching each cycle.

  ### CI/CD

  - Updated GitHub Actions (`checkout`, `setup-dotnet`, `upload-artifact`) to latest versions and enabled Node.js 24 to
  resolve deprecation warnings.