### PR TITLE
Enhance sell limits, add hotkey configuration, and version bump

### DIFF
--- a/ToonTown Rewritten Bot/Models/Hotkeys.cs
+++ b/ToonTown Rewritten Bot/Models/Hotkeys.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Windows.Forms;
+using ToonTown_Rewritten_Bot.Utilities;
+
+namespace ToonTown_Rewritten_Bot.Models
+{
+    /// <summary>
+    /// Holds the global hotkeys that control the bot (stop and pause). These are matched
+    /// against key presses seen by the global keyboard hook, so they work even while TTR
+    /// (or any other window) has focus.
+    ///
+    /// The keys are user-configurable via <see cref="Views.HotkeysForm"/> and persisted to
+    /// <see cref="UserPreferences"/>. Esc is offered as an optional stop key on its own toggle:
+    /// it is convenient in-game but, because the bot can run in the background, leaving it on
+    /// means pressing Esc in any other application also stops the bot — so users who hit that
+    /// can turn it off and rely on the dedicated stop key instead.
+    ///
+    /// Fields are <c>volatile</c> because they are written from the UI thread (when the user
+    /// saves new hotkeys) and read from the keyboard-hook callback thread.
+    /// </summary>
+    public static class Hotkeys
+    {
+        public static volatile Keys Stop = Keys.F12;
+        public static volatile Keys Pause = Keys.F11;
+        public static volatile bool AllowEscToStop = true;
+
+        /// <summary>Returns true if the given key should stop active tasks.</summary>
+        public static bool IsStop(Keys key)
+        {
+            return key == Stop || (AllowEscToStop && key == Keys.Escape);
+        }
+
+        /// <summary>Returns true if the given key should toggle pause/resume.</summary>
+        public static bool IsPause(Keys key)
+        {
+            return key == Pause;
+        }
+
+        /// <summary>
+        /// Applies the saved hotkeys from <see cref="UserPreferences"/> to the runtime fields.
+        /// Unparseable or empty values fall back to the defaults (F12 stop, F11 pause).
+        /// </summary>
+        public static void LoadFrom(UserPreferences prefs)
+        {
+            Stop = Parse(prefs.HotkeyStop, Keys.F12);
+            Pause = Parse(prefs.HotkeyPause, Keys.F11);
+            AllowEscToStop = prefs.HotkeyAllowEscToStop;
+        }
+
+        /// <summary>
+        /// Writes the current runtime hotkeys back into <see cref="UserPreferences"/>
+        /// (as enum-name strings) so they persist across sessions.
+        /// </summary>
+        public static void SaveTo(UserPreferences prefs)
+        {
+            prefs.HotkeyStop = Stop.ToString();
+            prefs.HotkeyPause = Pause.ToString();
+            prefs.HotkeyAllowEscToStop = AllowEscToStop;
+        }
+
+        /// <summary>Resets the runtime hotkeys to their defaults.</summary>
+        public static void ResetToDefaults()
+        {
+            Stop = Keys.F12;
+            Pause = Keys.F11;
+            AllowEscToStop = true;
+        }
+
+        private static Keys Parse(string value, Keys fallback)
+        {
+            if (!string.IsNullOrWhiteSpace(value) && Enum.TryParse(value, out Keys parsed))
+            {
+                return parsed;
+            }
+            return fallback;
+        }
+
+        /// <summary>
+        /// Returns a friendly, human-readable name for a key (e.g. "Esc", "1", "A") for
+        /// display in the hotkeys UI. Falls back to the enum name for uncommon keys.
+        /// </summary>
+        public static string GetDisplayName(Keys key)
+        {
+            switch (key)
+            {
+                case Keys.Escape: return "Esc";
+                case Keys.Space: return "Space";
+                case Keys.Return: return "Enter";
+                case Keys.Back: return "Backspace";
+                case Keys.ControlKey: return "Control";
+                case Keys.ShiftKey: return "Shift";
+                case Keys.Menu: return "Alt";
+            }
+
+            // Digit keys are D0..D9; numpad digits are NumPad0..NumPad9.
+            if (key >= Keys.D0 && key <= Keys.D9)
+            {
+                return ((char)('0' + (key - Keys.D0))).ToString();
+            }
+
+            return key.ToString();
+        }
+    }
+}

--- a/ToonTown Rewritten Bot/Properties/AssemblyInfo.cs
+++ b/ToonTown Rewritten Bot/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.0.0")]
-[assembly: AssemblyFileVersion("2.5.0.0")]
+[assembly: AssemblyVersion("2.6.0.0")]
+[assembly: AssemblyFileVersion("2.6.0.0")]

--- a/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj
+++ b/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj
@@ -14,7 +14,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.5.0.0</ApplicationVersion>
+    <ApplicationVersion>2.6.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj.user
+++ b/ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj.user
@@ -60,6 +60,9 @@
     <Compile Update="Views\GolfOverlayForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="Views\HotkeysForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Views\ImageRecognitionDebugForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ToonTown Rewritten Bot/Utilities/GlobalSettings.cs
+++ b/ToonTown Rewritten Bot/Utilities/GlobalSettings.cs
@@ -4,7 +4,7 @@
     {
         public static class ApplicationInfo
         {
-            public static string Version { get; } = "2.5.0";
+            public static string Version { get; } = "2.6.0";
             public static string Author { get; } = "primetime43";
         }
     }

--- a/ToonTown Rewritten Bot/Utilities/UserPreferences.cs
+++ b/ToonTown Rewritten Bot/Utilities/UserPreferences.cs
@@ -93,6 +93,11 @@ namespace ToonTown_Rewritten_Bot.Utilities
         public string ControlRight { get; set; } = "RIGHT";
         public string ControlJump { get; set; } = "CONTROL";
 
+        // Global hotkeys (stop/pause). Stored as WinForms Keys enum names.
+        public string HotkeyStop { get; set; } = "F12";
+        public string HotkeyPause { get; set; } = "F11";
+        public bool HotkeyAllowEscToStop { get; set; } = true;
+
         /// <summary>
         /// Saves current preferences to file.
         /// </summary>
@@ -184,6 +189,10 @@ namespace ToonTown_Rewritten_Bot.Utilities
             ControlLeft = "LEFT";
             ControlRight = "RIGHT";
             ControlJump = "CONTROL";
+
+            HotkeyStop = "F12";
+            HotkeyPause = "F11";
+            HotkeyAllowEscToStop = true;
 
             Save();
         }

--- a/ToonTown Rewritten Bot/Views/GameControlsForm.cs
+++ b/ToonTown Rewritten Bot/Views/GameControlsForm.cs
@@ -168,9 +168,13 @@ namespace ToonTown_Rewritten_Bot.Views
                     return true;
                 }
 
-                if (Enum.IsDefined(typeof(VirtualKeyCode), (int)keyCode))
+                // VirtualKeyCode's underlying type is ushort, so Enum.IsDefined must be given a
+                // ushort — passing an int throws ArgumentException ("underlying type was UInt16").
+                // WinForms Keys values share the same virtual-key numbering, so the cast is safe.
+                ushort vk = (ushort)keyCode;
+                if (Enum.IsDefined(typeof(VirtualKeyCode), vk))
                 {
-                    AssignKey(_capturing.Value, (VirtualKeyCode)(int)keyCode);
+                    AssignKey(_capturing.Value, (VirtualKeyCode)vk);
                     _capturing = null;
                     RefreshButtonLabels();
                     return true;

--- a/ToonTown Rewritten Bot/Views/HotkeysForm.cs
+++ b/ToonTown Rewritten Bot/Views/HotkeysForm.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using ToonTown_Rewritten_Bot.Models;
+using ToonTown_Rewritten_Bot.Utilities;
+
+namespace ToonTown_Rewritten_Bot.Views
+{
+    /// <summary>
+    /// Lets the user rebind the bot's global stop/pause hotkeys, plus toggle whether Esc
+    /// also stops. Bindings are applied to <see cref="Hotkeys"/> and persisted to
+    /// <see cref="UserPreferences"/> on Save.
+    /// </summary>
+    public class HotkeysForm : Form
+    {
+        private enum HotkeySlot { Stop, Pause }
+
+        private Keys _stop = Hotkeys.Stop;
+        private Keys _pause = Hotkeys.Pause;
+        private bool _allowEsc = Hotkeys.AllowEscToStop;
+
+        private readonly Button _btnStop = new Button();
+        private readonly Button _btnPause = new Button();
+        private readonly CheckBox _chkEsc = new CheckBox();
+
+        private HotkeySlot? _capturing;
+
+        public HotkeysForm()
+        {
+            BuildUi();
+            RefreshButtonLabels();
+        }
+
+        private void BuildUi()
+        {
+            Text = "Hotkeys";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            ClientSize = new Size(360, 240);
+
+            var intro = new Label
+            {
+                Location = new Point(15, 12),
+                Size = new Size(330, 56),
+                Text = "Set the global keys that stop and pause the bot. Click a button, " +
+                       "then press the key you want to use (these work even while TTR has focus)."
+            };
+            Controls.Add(intro);
+
+            int y = 80;
+            AddRow("Stop task:", _btnStop, HotkeySlot.Stop, ref y);
+            AddRow("Pause / Resume:", _btnPause, HotkeySlot.Pause, ref y);
+
+            _chkEsc.Location = new Point(175, y);
+            _chkEsc.Size = new Size(170, 24);
+            _chkEsc.Text = "Also allow Esc to stop";
+            _chkEsc.Checked = _allowEsc;
+            _chkEsc.CheckedChanged += (s, e) => _allowEsc = _chkEsc.Checked;
+            Controls.Add(_chkEsc);
+
+            var btnReset = new Button
+            {
+                Text = "Reset to Defaults",
+                Location = new Point(15, 192),
+                Size = new Size(130, 32)
+            };
+            btnReset.Click += (s, e) =>
+            {
+                _stop = Keys.F12;
+                _pause = Keys.F11;
+                _allowEsc = true;
+                _chkEsc.Checked = true;
+                CancelCapture();
+                RefreshButtonLabels();
+            };
+            Controls.Add(btnReset);
+
+            var btnSave = new Button
+            {
+                Text = "Save",
+                Location = new Point(185, 192),
+                Size = new Size(75, 32),
+                DialogResult = DialogResult.OK
+            };
+            btnSave.Click += BtnSave_Click;
+            Controls.Add(btnSave);
+
+            var btnCancel = new Button
+            {
+                Text = "Cancel",
+                Location = new Point(270, 192),
+                Size = new Size(75, 32),
+                DialogResult = DialogResult.Cancel
+            };
+            Controls.Add(btnCancel);
+
+            AcceptButton = btnSave;
+            CancelButton = btnCancel;
+        }
+
+        private void AddRow(string labelText, Button button, HotkeySlot slot, ref int y)
+        {
+            var label = new Label
+            {
+                Text = labelText,
+                Location = new Point(15, y + 6),
+                Size = new Size(150, 23),
+                TextAlign = ContentAlignment.MiddleLeft
+            };
+            Controls.Add(label);
+
+            button.Location = new Point(175, y);
+            button.Size = new Size(170, 30);
+            button.Tag = slot;
+            button.Click += BindButton_Click;
+            Controls.Add(button);
+
+            y += 40;
+        }
+
+        private void BindButton_Click(object sender, EventArgs e)
+        {
+            // Clicking a row that is already capturing cancels it.
+            var slot = (HotkeySlot)((Button)sender).Tag;
+            if (_capturing == slot)
+            {
+                CancelCapture();
+                return;
+            }
+
+            CancelCapture();
+            _capturing = slot;
+            ButtonFor(slot).Text = "Press a key…";
+        }
+
+        private void BtnSave_Click(object sender, EventArgs e)
+        {
+            Hotkeys.Stop = _stop;
+            Hotkeys.Pause = _pause;
+            Hotkeys.AllowEscToStop = _allowEsc;
+
+            var prefs = UserPreferences.Instance;
+            Hotkeys.SaveTo(prefs);
+            prefs.Save();
+        }
+
+        /// <summary>
+        /// While a row is in capture mode, intercept the next key press and bind it.
+        /// ProcessCmdKey reliably sees function keys and other keys that a normal KeyDown
+        /// handler might otherwise consume for navigation. Esc cancels capture rather than
+        /// binding (it has its own toggle), so the stop/pause keys are always a real key.
+        /// </summary>
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_capturing != null)
+            {
+                Keys keyCode = keyData & Keys.KeyCode;
+
+                if (keyCode == Keys.Escape)
+                {
+                    CancelCapture();
+                    return true;
+                }
+
+                // Ignore lone modifier presses so a bind doesn't capture just "Shift"/"Control".
+                if (keyCode == Keys.ShiftKey || keyCode == Keys.ControlKey || keyCode == Keys.Menu)
+                {
+                    return true;
+                }
+
+                AssignKey(_capturing.Value, keyCode);
+                _capturing = null;
+                RefreshButtonLabels();
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void AssignKey(HotkeySlot slot, Keys key)
+        {
+            switch (slot)
+            {
+                case HotkeySlot.Stop: _stop = key; break;
+                case HotkeySlot.Pause: _pause = key; break;
+            }
+        }
+
+        private void CancelCapture()
+        {
+            if (_capturing != null)
+            {
+                _capturing = null;
+                RefreshButtonLabels();
+            }
+        }
+
+        private Button ButtonFor(HotkeySlot slot)
+        {
+            return slot switch
+            {
+                HotkeySlot.Stop => _btnStop,
+                HotkeySlot.Pause => _btnPause,
+                _ => _btnStop
+            };
+        }
+
+        private void RefreshButtonLabels()
+        {
+            _btnStop.Text = Hotkeys.GetDisplayName(_stop);
+            _btnPause.Text = Hotkeys.GetDisplayName(_pause);
+        }
+    }
+}

--- a/ToonTown Rewritten Bot/Views/HotkeysForm.resx
+++ b/ToonTown Rewritten Bot/Views/HotkeysForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ToonTown Rewritten Bot/Views/MainForm.Designer.cs
+++ b/ToonTown Rewritten Bot/Views/MainForm.Designer.cs
@@ -188,6 +188,7 @@
             btnOpenPreferencesFile = new System.Windows.Forms.Button();
             btnSavePreferencesNow = new System.Windows.Forms.Button();
             btnGameControls = new System.Windows.Forms.Button();
+            btnHotkeys = new System.Windows.Forms.Button();
             groupBoxKeyboardShortcuts = new System.Windows.Forms.GroupBox();
             labelKeyboardShortcuts = new System.Windows.Forms.Label();
             groupBoxAboutSettings = new System.Windows.Forms.GroupBox();
@@ -2013,6 +2014,7 @@
             // 
             Settings.Controls.Add(groupBoxPreferences);
             Settings.Controls.Add(btnGameControls);
+            Settings.Controls.Add(btnHotkeys);
             Settings.Controls.Add(groupBoxKeyboardShortcuts);
             Settings.Controls.Add(groupBoxAboutSettings);
             Settings.Location = new System.Drawing.Point(4, 25);
@@ -2109,6 +2111,18 @@
             toolTip1.SetToolTip(btnGameControls, "Tell the bot which movement keys you have bound in TTR's Controls screen");
             btnGameControls.UseVisualStyleBackColor = true;
             btnGameControls.Click += btnGameControls_Click;
+            //
+            // btnHotkeys
+            //
+            btnHotkeys.Location = new System.Drawing.Point(9, 340);
+            btnHotkeys.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnHotkeys.Name = "btnHotkeys";
+            btnHotkeys.Size = new System.Drawing.Size(350, 35);
+            btnHotkeys.TabIndex = 4;
+            btnHotkeys.Text = "Configure Hotkeys...";
+            toolTip1.SetToolTip(btnHotkeys, "Rebind the global stop/pause keys (and toggle whether Esc also stops)");
+            btnHotkeys.UseVisualStyleBackColor = true;
+            btnHotkeys.Click += btnHotkeys_Click;
             //
             // groupBoxKeyboardShortcuts
             //
@@ -2700,6 +2714,7 @@
         private System.Windows.Forms.Button btnOpenPreferencesFile;
         private System.Windows.Forms.Button btnSavePreferencesNow;
         private System.Windows.Forms.Button btnGameControls;
+        private System.Windows.Forms.Button btnHotkeys;
         private System.Windows.Forms.GroupBox groupBoxKeyboardShortcuts;
         private System.Windows.Forms.Label labelKeyboardShortcuts;
         private System.Windows.Forms.GroupBox groupBoxAboutSettings;

--- a/ToonTown Rewritten Bot/Views/MainForm.Designer.cs
+++ b/ToonTown Rewritten Bot/Views/MainForm.Designer.cs
@@ -502,7 +502,7 @@
             // 
             numericUpDownSells.Location = new System.Drawing.Point(60, 96);
             numericUpDownSells.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            numericUpDownSells.Maximum = new decimal(new int[] { 50, 0, 0, 0 });
+            numericUpDownSells.Maximum = new decimal(new int[] { 999, 0, 0, 0 });
             numericUpDownSells.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             numericUpDownSells.Name = "numericUpDownSells";
             numericUpDownSells.Size = new System.Drawing.Size(48, 22);
@@ -880,7 +880,7 @@
             // 
             numericUpDownCustomSells.Location = new System.Drawing.Point(145, 113);
             numericUpDownCustomSells.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            numericUpDownCustomSells.Maximum = new decimal(new int[] { 50, 0, 0, 0 });
+            numericUpDownCustomSells.Maximum = new decimal(new int[] { 999, 0, 0, 0 });
             numericUpDownCustomSells.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             numericUpDownCustomSells.Name = "numericUpDownCustomSells";
             numericUpDownCustomSells.Size = new System.Drawing.Size(55, 22);
@@ -1592,11 +1592,11 @@
             numberOfDoodleFeedsNumericUpDown.Location = new System.Drawing.Point(85, 104);
             numberOfDoodleFeedsNumericUpDown.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             numberOfDoodleFeedsNumericUpDown.Maximum = new decimal(new int[] { 900, 0, 0, 0 });
-            numberOfDoodleFeedsNumericUpDown.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numberOfDoodleFeedsNumericUpDown.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numberOfDoodleFeedsNumericUpDown.Name = "numberOfDoodleFeedsNumericUpDown";
             numberOfDoodleFeedsNumericUpDown.Size = new System.Drawing.Size(55, 22);
             numberOfDoodleFeedsNumericUpDown.TabIndex = 3;
-            toolTip1.SetToolTip(numberOfDoodleFeedsNumericUpDown, "Number of times to feed your doodle per cycle");
+            toolTip1.SetToolTip(numberOfDoodleFeedsNumericUpDown, "Number of times to feed your doodle per cycle (0 = skip feeding)");
             numberOfDoodleFeedsNumericUpDown.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // doodleFeedsTimesLabel
@@ -1624,11 +1624,11 @@
             numberOfDoodleScratchesNumericUpDown.Location = new System.Drawing.Point(85, 134);
             numberOfDoodleScratchesNumericUpDown.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             numberOfDoodleScratchesNumericUpDown.Maximum = new decimal(new int[] { 900, 0, 0, 0 });
-            numberOfDoodleScratchesNumericUpDown.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numberOfDoodleScratchesNumericUpDown.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numberOfDoodleScratchesNumericUpDown.Name = "numberOfDoodleScratchesNumericUpDown";
             numberOfDoodleScratchesNumericUpDown.Size = new System.Drawing.Size(55, 22);
             numberOfDoodleScratchesNumericUpDown.TabIndex = 6;
-            toolTip1.SetToolTip(numberOfDoodleScratchesNumericUpDown, "Number of times to scratch your doodle per cycle");
+            toolTip1.SetToolTip(numberOfDoodleScratchesNumericUpDown, "Number of times to scratch your doodle per cycle (0 = skip scratching)");
             numberOfDoodleScratchesNumericUpDown.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // doodleScratchesTimesLabel

--- a/ToonTown Rewritten Bot/Views/MainForm.DoodleTraining.cs
+++ b/ToonTown Rewritten Bot/Views/MainForm.DoodleTraining.cs
@@ -47,6 +47,21 @@ namespace ToonTown_Rewritten_Bot
             bool justScratch = justScratchDoodleCheckBox.Checked;
             bool backgroundMode = doodleBackgroundModeCheckBox.Checked;
 
+            // Feeds/scratches of 0 are allowed (e.g. to just spam a trick), but each cycle must do
+            // something — otherwise the loop just waits forever doing nothing. The feed phase is
+            // skipped when justScratch is set, and the scratch phase when justFeed is set.
+            int effectiveFeeds = justScratch ? 0 : numberOfFeeds;
+            int effectiveScratches = justFeed ? 0 : numberOfScratches;
+            bool hasTrick = selectedTrick != "None";
+            if (effectiveFeeds == 0 && effectiveScratches == 0 && !hasTrick)
+            {
+                MessageBox.Show(
+                    "Nothing to do: feeds and scratches are both 0 and no trick is selected.\n\n" +
+                    "Set feeds or scratches above 0, or pick a trick to perform.",
+                    "Invalid Settings", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
             // Ensure we have a fresh CancellationTokenSource
             if (_cancellationTokenSource != null)
             {

--- a/ToonTown Rewritten Bot/Views/MainForm.Settings.cs
+++ b/ToonTown Rewritten Bot/Views/MainForm.Settings.cs
@@ -92,6 +92,22 @@ namespace ToonTown_Rewritten_Bot
         }
 
         /// <summary>
+        /// Opens the Hotkeys dialog so the user can rebind the global stop/pause keys.
+        /// </summary>
+        private void btnHotkeys_Click(object sender, EventArgs e)
+        {
+            using (var form = new Views.HotkeysForm())
+            {
+                if (form.ShowDialog(this) == DialogResult.OK)
+                {
+                    // Reflect the new bindings in the on-screen shortcut hints and the list.
+                    UpdateShortcutLabels();
+                    RefreshPreferencesDisplay();
+                }
+            }
+        }
+
+        /// <summary>
         /// Refreshes the preferences list box with current saved values.
         /// </summary>
         private void RefreshPreferencesDisplay()
@@ -147,6 +163,12 @@ namespace ToonTown_Rewritten_Bot
             preferencesListBox.Items.Add($"  Left: {Models.GameControls.GetDisplayName(Models.GameControls.Left)}");
             preferencesListBox.Items.Add($"  Right: {Models.GameControls.GetDisplayName(Models.GameControls.Right)}");
             preferencesListBox.Items.Add($"  Jump: {Models.GameControls.GetDisplayName(Models.GameControls.Jump)}");
+
+            preferencesListBox.Items.Add("");
+            preferencesListBox.Items.Add("═══════ HOTKEYS ═══════");
+            preferencesListBox.Items.Add($"  Stop: {Models.Hotkeys.GetDisplayName(Models.Hotkeys.Stop)}");
+            preferencesListBox.Items.Add($"  Pause/Resume: {Models.Hotkeys.GetDisplayName(Models.Hotkeys.Pause)}");
+            preferencesListBox.Items.Add($"  Esc also stops: {(Models.Hotkeys.AllowEscToStop ? "Yes" : "No")}");
 
             preferencesListBox.Items.Add("");
             preferencesListBox.Items.Add("═══════ MISC ═══════");

--- a/ToonTown Rewritten Bot/Views/MainForm.cs
+++ b/ToonTown Rewritten Bot/Views/MainForm.cs
@@ -174,6 +174,29 @@ namespace ToonTown_Rewritten_Bot
 
             // Game control bindings — apply saved key bindings to the input layer.
             Models.GameControls.LoadFrom(prefs);
+
+            // Global stop/pause hotkeys — apply saved bindings, then reflect them in the UI hints.
+            Models.Hotkeys.LoadFrom(prefs);
+            UpdateShortcutLabels();
+        }
+
+        /// <summary>
+        /// Updates the on-screen "Keyboard Shortcuts" hint labels to reflect the currently
+        /// configured stop/pause hotkeys (so they stay correct after the user rebinds them).
+        /// </summary>
+        private void UpdateShortcutLabels()
+        {
+            string pause = Models.Hotkeys.GetDisplayName(Models.Hotkeys.Pause);
+            string stop = Models.Hotkeys.GetDisplayName(Models.Hotkeys.Stop);
+            string stopKeys = Models.Hotkeys.AllowEscToStop ? $"{stop} or Esc" : stop;
+
+            shortcutsLabel.Text = $"{pause,-10} Pause / Resume\r\n{stopKeys,-10} Stop task";
+            fishingShortcutsLabel.Text = $"Keyboard Shortcuts:\n{pause} - Pause/Resume\n{stopKeys} - Stop";
+            labelKeyboardShortcuts.Text =
+                "Global shortcuts (work in-game):\n\n" +
+                $"{pause} - Pause/Resume fishing\n" +
+                $"{stopKeys} - Stop current task\n\n" +
+                "These work even when TTR\nhas focus.";
         }
 
         /// <summary>
@@ -233,17 +256,20 @@ namespace ToonTown_Rewritten_Bot
             // Game control bindings — persist the current key bindings.
             Models.GameControls.SaveTo(prefs);
 
+            // Global stop/pause hotkeys — persist the current bindings.
+            Models.Hotkeys.SaveTo(prefs);
+
             prefs.Save();
         }
 
         /// <summary>
         /// Global keyboard shortcut handler.
-        /// Press Escape or F12 to stop fishing/other active tasks.
+        /// Press the configured stop hotkey (default F12, plus Esc when enabled) to stop tasks.
         /// </summary>
         private void MainForm_KeyDown(object sender, KeyEventArgs e)
         {
-            // Escape or F12 stops fishing and other active tasks
-            if (e.KeyCode == Keys.Escape || e.KeyCode == Keys.F12)
+            // Configured stop hotkey stops fishing and other active tasks
+            if (Models.Hotkeys.IsStop(e.KeyCode))
             {
                 StopAllActiveTasks();
                 e.Handled = true;
@@ -268,7 +294,7 @@ namespace ToonTown_Rewritten_Bot
         /// </summary>
         private void GlobalKeyboardHook_KeyPressed(object sender, Keys key)
         {
-            if (key == Keys.Escape || key == Keys.F12)
+            if (Models.Hotkeys.IsStop(key))
             {
                 // Ignore simulated key presses (e.g., from StraightenToonAsync sending ESC to cancel a cast)
                 if (FishingStrategyBase.IsSimulatedKeyPress)
@@ -277,7 +303,15 @@ namespace ToonTown_Rewritten_Bot
                     return;
                 }
 
-                // Suppress the key so it doesn't reach the game
+                // Only swallow the key (so it doesn't reach the game/other apps) when there is
+                // actually a task to stop. Otherwise a stop key rebound to a normal character
+                // would be eaten globally even while the bot is idle.
+                bool taskActive = _cancellationTokenSource != null && !_cancellationTokenSource.IsCancellationRequested;
+                if (!taskActive)
+                {
+                    return;
+                }
+
                 _globalKeyboardHook.SuppressKey = true;
 
                 // Stop all active tasks — catch blocks in start handlers show the feedback
@@ -290,7 +324,7 @@ namespace ToonTown_Rewritten_Bot
                     StopAllActiveTasks();
                 }
             }
-            else if (key == Keys.F11)
+            else if (Models.Hotkeys.IsPause(key))
             {
                 // Toggle pause for fishing
                 FishingStrategyBase.TogglePause();


### PR DESCRIPTION
This pull request introduces a new feature that allows users to configure the bot's global stop and pause hotkeys via a dedicated UI, and persists these preferences. It also includes minor improvements and version updates. The most important changes are grouped below:

### Hotkey Customization Feature

* Added a new `Hotkeys` class to manage global stop/pause hotkeys, including support for toggling whether the Escape key also stops the bot. These hotkeys are now user-configurable and persisted in `UserPreferences`. (`ToonTown Rewritten Bot/Models/Hotkeys.cs`)
* Added a new `HotkeysForm` UI to allow users to rebind the stop/pause hotkeys and toggle the Escape key functionality. (`ToonTown Rewritten Bot/Views/HotkeysForm.cs`, `ToonTown Rewritten Bot/Views/HotkeysForm.resx`) [[1]](diffhunk://#diff-6526de764fcf4a48c56211e9ea65e8df3de3007751adcf584d64e9232a835c28R1-R216) [[2]](diffhunk://#diff-d035b90619299a22434e27539fa786a34a99195f8508de51bd1582eac4ef0345R1-R120)
* Updated `UserPreferences` to store hotkey settings and reset them to defaults when requested. (`ToonTown Rewritten Bot/Utilities/UserPreferences.cs`) [[1]](diffhunk://#diff-456fda1b494948346fba05b5efd0e1c50c1e31d5532a059b47e930e12408e877R96-R100) [[2]](diffhunk://#diff-456fda1b494948346fba05b5efd0e1c50c1e31d5532a059b47e930e12408e877R193-R196)
* Added the new hotkey configuration form to the project file. (`ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj.user`)

### UI and Usability Improvements

* Increased the maximum value for `numericUpDownSells` and `numericUpDownCustomSells` controls from 50 to 999, allowing for larger input values. (`ToonTown Rewritten Bot/Views/MainForm.Designer.cs`) [[1]](diffhunk://#diff-8503cdcb89b282c00851933fdc0739ee8cc7fdb7e90956c06730b4d920868876L505-R506) [[2]](diffhunk://#diff-8503cdcb89b282c00851933fdc0739ee8cc7fdb7e90956c06730b4d920868876L883-R884)
* Added a button to open the new Hotkeys configuration form in the main window. (`ToonTown Rewritten Bot/Views/MainForm.Designer.cs`)

### Bugfixes and Technical Improvements

* Fixed an issue in key binding logic to ensure compatibility with the underlying enum type for virtual key codes. (`ToonTown Rewritten Bot/Views/GameControlsForm.cs`)

### Version Updates

* Bumped the application version to 2.6.0 in all relevant files. (`ToonTown Rewritten Bot/ToonTown Rewritten Bot.csproj`, `ToonTown Rewritten Bot/Properties/AssemblyInfo.cs`, `ToonTown Rewritten Bot/Utilities/GlobalSettings.cs`) [[1]](diffhunk://#diff-32ee4abe41e69ffcc8ddbf45e9227edbe9b2ee6266259984ad5f6d7acabb65bcL17-R17) [[2]](diffhunk://#diff-1f217727232f407c6458a5927ff5c0d427e415ef24982f47449ee87f8fdeab21L35-R36) [[3]](diffhunk://#diff-47270a0fc1394219737631905756fb1bc89346eff4722c7c8578a885032c163eL7-R7)